### PR TITLE
ITHC change 6.3.3 to enable http2.0 and disable ftp 

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -132,7 +132,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/templates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ARMTemplates/",
         "resourceNamePrefix": "[toLower(concat(parameters('resourceIdentifier') , parameters('resourceEnvironmentName'), '-', parameters('serviceName')))]",
         "storageAccountName": "[toLower(concat(parameters('resourceIdentifier'), parameters('resourceEnvironmentName'), parameters('serviceName'), 'str'))]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
@@ -157,6 +157,9 @@
                 "parameters": {
                     "storageAccountName": {
                         "value": "[variables('storageAccountName')]"
+                    },
+                    "storageKind": {
+                        "value": "Storage"
                     }
                 }
             }
@@ -168,7 +171,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan-ase.json')]",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -285,6 +288,12 @@
                     },
                     "certificateThumbprint": {
                         "value": "[if(greater(length(parameters('uiCustomHostname')), 0), reference('ui-app-service-certificate', '2018-11-01').outputs.certificateThumbprint.value, '')]"
+                    },
+                    "http20Enabled": {
+                        "value": true
+                    },
+                    "ftpsState": {
+                        "value": "Disabled"
                     }
                 }
             },
@@ -499,6 +508,12 @@
                     },
                     "certificateThumbprint": {
                         "value": "[if(greater(length(parameters('internalApiCustomHostname')), 0), reference('internal-api-app-service-certificate', '2018-11-01').outputs.certificateThumbprint.value, '')]"
+                    },
+                    "http20Enabled" : {
+                        "value": true
+                    },
+                    "ftpsState" : {
+                        "value": "Disabled"
                     }
                 }
             },
@@ -638,6 +653,12 @@
                     },
                     "systemAssignedIdentity": {
                         "value": "SystemAssigned"
+                    },
+                    "http20Enabled" : {
+                        "value": true
+                    },
+                    "ftpsState": {
+                        "value": "Disabled"
                     }
                 }
             }

--- a/azure/template.json
+++ b/azure/template.json
@@ -132,7 +132,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ARMTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
         "resourceNamePrefix": "[toLower(concat(parameters('resourceIdentifier') , parameters('resourceEnvironmentName'), '-', parameters('serviceName')))]",
         "storageAccountName": "[toLower(concat(parameters('resourceIdentifier'), parameters('resourceEnvironmentName'), parameters('serviceName'), 'str'))]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",

--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -92,7 +92,7 @@
         }		
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/operations-devops-deployment/reasc-staging-slot/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
         "uiAppName": "[concat(parameters('resourceNamePrefix'), '-web')]",
         "internalApiAppName": "[concat(parameters('resourceNamePrefix'), '-internal-api')]",
         "appInsightName": "[concat(parameters('resourceNamePrefix'), '-ai')]",

--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -249,6 +249,12 @@
                     },
                     "certificateThumbprint": {
                         "value": "[if(greater(length(parameters('uiCustomHostname')), 0), reference(concat('ui-app-service-certificate','-', parameters('environmentNameAbbreviation')), '2018-11-01').outputs.certificateThumbprint.value, '')]"
+                    },
+                    "http20Enabled": {
+                        "value": true
+                    },
+                    "ftpsState": {
+                        "value": "Disabled"
                     }
                 }
             },
@@ -335,6 +341,12 @@
                     },
                     "certificateThumbprint": {
                         "value": "[if(greater(length(parameters('internalApiCustomHostname')), 0), reference(concat('internal-api-app-service-certificate','-',parameters('environmentNameAbbreviation')), '2018-11-01').outputs.certificateThumbprint.value, '')]"
+                    },
+                    "http20Enabled": {
+                        "value": true
+                    },
+                    "ftpsState": {
+                        "value": "Disabled"
                     }
                 }
             },
@@ -485,6 +497,12 @@
                     },
                     "systemAssignedIdentity": {
                         "value": "SystemAssigned"
+                    },
+                    "http20Enabled": {
+                        "value": true
+                    },
+                    "ftpsState": {
+                        "value": "Disabled"
                     }
                 }
             },

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -62,7 +62,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/operations-devops-deployment/reasc-staging-slot/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
         "sharedStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'sharedstr'), '-', '')]",


### PR DESCRIPTION
existing pipeline uses template.json, migrated to ARMTemplates folder with more recent contents but kept backwards compatible

also updated tlevels-environment.json and tlevels-shared.json to ensure changes are not lost in transition.

Changes in SkillsFundingAgency/tl-platform-building-blocks have been merged to master


