### PR TITLE
Release20.1 (#502)

### DIFF
--- a/src/Sfa.Tl.ResultsAndCertification.Application/Mappers/LearnerMapper.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Application/Mappers/LearnerMapper.cs
@@ -65,8 +65,6 @@ namespace Sfa.Tl.ResultsAndCertification.Application.Mappers
                .ForMember(d => d.LarId, opts => opts.MapFrom(s => s.TlSpecialism.LarId))
                .ForMember(d => d.Name, opts => opts.MapFrom(s => s.TlSpecialism.Name))
                .ForMember(d => d.TlSpecialismCombinations, opts => opts.MapFrom(s => s.TqRegistrationPathway.TqProvider.TqAwardingOrganisation.TlPathway.TlPathwaySpecialismCombinations
-                                .Where(t => t.IsActive && s.TlSpecialism.TlPathwaySpecialismCombinations.Where(t => t.IsActive)
-                                .Select(c => c.GroupId).Contains(t.GroupId))
                                 .GroupBy(g => g.GroupId)
                                 .Select(c => new KeyValuePair<int, string>(c.Key, string.Join(Constants.PipeSeperator, c.Select(i => i.TlSpecialism.LarId))))))
                .ForMember(d => d.Assessments, opts => opts.MapFrom(s => s.TqSpecialismAssessments));


### PR DESCRIPTION
* Link text updated (#481)

* Filter by active specialisms (#482)

* provider address implementation (#483)

* Filter inactive courses (#484)

* Tl2023 24 (#485)

* provider address implementation

* Name change

* Make it fail when an inactive specialism is sent in the CSV file (#486)

* Prevent users from uploading inactive course registrations (#487)

* Tl2023 24 (#488)

* provider address implementation

* Name change

* update the mapping

* Tl2023 24 (#489)

* provider address implementation

* Name change

* update the mapping

* add missing mapping

* Updated text (#491)

* Tl2023 24 (#490)

* provider address implementation

* Name change

* update the mapping

* add missing mapping

* Mapping trigger

* Remove h3 tag (#492)

* Filter inactive pathways (#494)

* Tl2023 24 (#495)

* provider address implementation

* Name change

* update the mapping

* add missing mapping

* Mapping trigger

* getting only isactive addresses

* Change headers (#496)

* Remove filter (#499)

---------