### PR TITLE
Feature/tld 7 working yaml pipeline

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -116,6 +116,9 @@
                 "parameters": {
                     "storageAccountName": {
                         "value": "[variables('storageAccountName')]"
+                    },
+                    "storageKind": {
+                        "value": "StorageV2"
                     }
                 }
             }

--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -92,7 +92,7 @@
         }		
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/operations-devops-deployment/reasc-staging-slot/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
         "uiAppName": "[concat(parameters('resourceNamePrefix'), '-web')]",
         "internalApiAppName": "[concat(parameters('resourceNamePrefix'), '-internal-api')]",
         "appInsightName": "[concat(parameters('resourceNamePrefix'), '-ai')]",

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -62,7 +62,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/operations-devops-deployment/reasc-staging-slot/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
         "sharedStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'sharedstr'), '-', '')]",
@@ -216,7 +216,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan-ase.json')]",
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -167,6 +167,9 @@
                 "parameters": {
                     "storageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    },
+                    "storageKind": {
+                        "value": "StorageV2"
                     }
                 }
             }
@@ -248,6 +251,9 @@
                 "parameters": {
                     "storageAccountName": {
                         "value": "[variables('configStorageAccountName')]"
+                    },
+                    "storageKind": {
+                        "value": "StorageV2"
                     }
                 }
             }


### PR DESCRIPTION
PR for work required to use the ARM templates in tl-platform-building-blocks repo.

Updated deploymentUrlBase value.

Set the storage account kind, as the default of this value has changed, but needs to be set to StorageV2 as you can't change a storage account kind once it's been deployed.