### PR TITLE
Updated sql pipeline reference

### DIFF
--- a/azure-pipelines-new.yml
+++ b/azure-pipelines-new.yml
@@ -26,6 +26,8 @@ pool:
   vmImage: 'windows-latest' #'vs2017-win2016'
   
 variables:
-  applicationName: resac
+- template: ./Automation/variables/vars-global.yml@devopsTemplates
+- name: applicationName
+  value: resac
 stages:
   - template: ./yaml/stages/tlevels-master-stage.yml


### PR DESCRIPTION
Updated code to use the sql firewall restrictions yaml variable and removed library group variable.

The new Resac pipeline will fail until https://github.com/DFE-Digital/operations-devops-pipeline-templates/pull/12 is merged.