### PR TITLE
Replica server/database deployment

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -69,8 +69,8 @@
         "learnerGenderTrigger": {
             "type": "string"
         },
-		"certificatePrintingBatchesCreateTrigger": {
-            "type": "string"            
+        "certificatePrintingBatchesCreateTrigger": {
+            "type": "string"
         },
         "certificatePrintingRequestTrigger": {
             "type": "string"
@@ -90,8 +90,8 @@
         "ucasTransferAmendmentsTrigger": {
             "type": "string"
         },
-		"overallResultCalculationTrigger": {
-            "type": "string"            
+        "overallResultCalculationTrigger": {
+            "type": "string"
         },
         "enableReplica": {
             "type": "bool",
@@ -451,7 +451,7 @@
                                 "name": "LearnerGenderTrigger",
                                 "value": "[parameters('learnerGenderTrigger')]"
                             },
-							{
+                            {
                                 "name": "CertificatePrintingBatchesCreateTrigger",
                                 "value": "[parameters('certificatePrintingBatchesCreateTrigger')]"
                             },
@@ -479,10 +479,10 @@
                                 "name": "UcasTransferAmendmentsTrigger",
                                 "value": "[parameters('ucasTransferAmendmentsTrigger')]"
                             },
-							{
+                            {
                                 "name": "OverallResultCalculationTrigger",
                                 "value": "[parameters('overallResultCalculationTrigger')]"
-                            },							
+                            },
                             {
                                 "name": "WEBSITE_LOAD_CERTIFICATES",
                                 "value": "1"
@@ -563,10 +563,10 @@
                     "serverlessAutoPauseDelay": {
                         "value": "[parameters('sqlserverlessAutoPauseDelay')]"
                     },
-                    "createMode":{
+                    "createMode": {
                         "value": "Secondary"
                     },
-                    "sourceDatabaseId":{
+                    "sourceDatabaseId": {
                         "value": "[reference(concat('sql-database','-', parameters('environmentNameAbbreviation'),'-','shared')).outputs.sqlDatabaseResourceId.value]"
                     },
                     "requestedBackupStorageRedundancy": {

--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -503,7 +503,6 @@
             "dependsOn": [
                 "[concat('function-app-certificate','-', parameters('environmentNameAbbreviation'))]",
                 "[concat('app-insights','-', parameters('environmentNameAbbreviation'))]"
-
             ]
         },
         {
@@ -538,7 +537,7 @@
         },
         {
             "condition": "[equals(parameters('enableReplica'), true())]",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2022-09-01",
             "name": "[concat('sql-database','-', parameters('environmentNameAbbreviation'),'-','replica')]",
             "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
             "type": "Microsoft.Resources/deployments",
@@ -563,9 +562,21 @@
                     },
                     "serverlessAutoPauseDelay": {
                         "value": "[parameters('sqlserverlessAutoPauseDelay')]"
+                    },
+                    "createMode":{
+                        "value": "Secondary"
+                    },
+                    "sourceDatabaseId":{
+                        "value": "[reference(concat('sql-database','-', parameters('environmentNameAbbreviation'),'-','shared')).outputs.sqlDatabaseResourceId.value]"
+                    },
+                    "requestedBackupStorageRedundancy": {
+                        "value": "Local"
                     }
                 }
-            }
+            },
+            "dependsOn": [
+                "[concat('sql-database','-', parameters('environmentNameAbbreviation'),'-','shared')]"
+            ]
         },
         {
             "apiVersion": "2017-05-10",
@@ -598,7 +609,7 @@
             }
         },
         {
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2022-09-01",
             "name": "[concat('sql-server-firewall-rules','-', parameters('environmentNameAbbreviation'))]",
             "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
             "type": "Microsoft.Resources/deployments",

--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -20,6 +20,9 @@
         "sharedSQLServerName": {
             "type": "string"
         },
+        "sharedSQLServerReplicaName": {
+            "type": "string"
+        },
         "sqlDatabaseSkuName": {
             "type": "string"
         },
@@ -99,7 +102,9 @@
         "functionAppName": "[concat(parameters('resourceNamePrefix'), '-func')]",
         "sqlDatabaseName": "[concat(parameters('resourceNamePrefix'), '-sqldb')]",
         "IntTestSQLDatabaseName": "[concat(parameters('resourceNamePrefix'), '-inttest-sqldb')]",
-        "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'str'), '-', '')]"
+        "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'str'), '-', '')]",
+        "sqlServerNames": "[createArray(parameters('sharedSQLServerName'), parameters('sharedSQLServerReplicaName'))]"
+
     },
     "resources": [
         {
@@ -498,7 +503,7 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "[concat('sql-database','-', parameters('environmentNameAbbreviation'))]",
+            "name": "[concat('sql-database','-', parameters('environmentNameAbbreviation'), copyIndex())]",
             "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
@@ -512,7 +517,7 @@
                         "value": "[variables('sqlDatabaseName')]"
                     },
                     "sqlServerName": {
-                        "value": "[parameters('sharedSQLServerName')]"
+                        "value": "[variables('sqlServerNames')[copyIndex()]]"
                     },
                     "databaseSkuName": {
                         "value": "[parameters('sqlDatabaseSkuName')]"
@@ -524,6 +529,11 @@
                         "value": "[parameters('sqlserverlessAutoPauseDelay')]"
                     }
                 }
+            },
+            "copy": {
+                "count": "[length(variables('sqlServerNames'))]",
+                "name": "firewallrulecopy",
+                "mode": "Parallel"
             }
         },
         {

--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -92,6 +92,13 @@
         },
 		"overallResultCalculationTrigger": {
             "type": "string"            
+        },
+        "enableReplica": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Enables the replica database to be deployed"
+            }
         }
     },
     "variables": {
@@ -102,9 +109,7 @@
         "functionAppName": "[concat(parameters('resourceNamePrefix'), '-func')]",
         "sqlDatabaseName": "[concat(parameters('resourceNamePrefix'), '-sqldb')]",
         "IntTestSQLDatabaseName": "[concat(parameters('resourceNamePrefix'), '-inttest-sqldb')]",
-        "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'str'), '-', '')]",
-        "sqlServerNames": "[createArray(parameters('sharedSQLServerName'), parameters('sharedSQLServerReplicaName'))]"
-
+        "storageAccountName": "[replace(concat(parameters('resourceNamePrefix'), 'str'), '-', '')]"
     },
     "resources": [
         {
@@ -503,7 +508,7 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "[concat('sql-database','-', parameters('environmentNameAbbreviation'), copyIndex())]",
+            "name": "[concat('sql-database','-', parameters('environmentNameAbbreviation'),'-','shared')]",
             "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
@@ -517,7 +522,7 @@
                         "value": "[variables('sqlDatabaseName')]"
                     },
                     "sqlServerName": {
-                        "value": "[variables('sqlServerNames')[copyIndex()]]"
+                        "value": "[parameters('sharedSQLServerName')]"
                     },
                     "databaseSkuName": {
                         "value": "[parameters('sqlDatabaseSkuName')]"
@@ -529,11 +534,37 @@
                         "value": "[parameters('sqlserverlessAutoPauseDelay')]"
                     }
                 }
-            },
-            "copy": {
-                "count": "[length(variables('sqlServerNames'))]",
-                "name": "firewallrulecopy",
-                "mode": "Parallel"
+            }
+        },
+        {
+            "condition": "[equals(parameters('enableReplica'), true())]",
+            "apiVersion": "2017-05-10",
+            "name": "[concat('sql-database','-', parameters('environmentNameAbbreviation'),'-','replica')]",
+            "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'sql-database.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "databaseName": {
+                        "value": "[variables('sqlDatabaseName')]"
+                    },
+                    "sqlServerName": {
+                        "value": "[parameters('sharedSQLServerReplicaName')]"
+                    },
+                    "databaseSkuName": {
+                        "value": "[parameters('sqlDatabaseSkuName')]"
+                    },
+                    "databaseTier": {
+                        "value": "[parameters('sqlDatabaseTier')]"
+                    },
+                    "serverlessAutoPauseDelay": {
+                        "value": "[parameters('sqlserverlessAutoPauseDelay')]"
+                    }
+                }
             }
         },
         {

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -75,7 +75,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/feature/TLD-295-rework-SQL-firewall-rules/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
         "sqlServerReplicaName": "[concat(variables('resourceNamePrefix'), '-shared-sql-replica')]",

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -65,6 +65,13 @@
         },
         "sqlFirewallIpAddressesPredefined": {
             "type": "array"
+        },
+        "enableReplica": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Enables the replica database to be deployed"
+            }
         }
     },
     "variables": {
@@ -72,7 +79,7 @@
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
         "sqlServerReplicaName": "[concat(variables('resourceNamePrefix'), '-shared-sql-replica')]",
-        "sqlServerNames": "[createArray(variables('sqlServerName'), variables('sqlServerReplicaName'))]",
+        "sqlServerNames": "[if(equals(parameters('enableReplica'), true()), createArray(variables('sqlServerName'), variables('sqlServerReplicaName')), createArray(variables('sqlServerName')))]",
         "sharedStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'sharedstr'), '-', '')]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-shared-asp')]",
         "configStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'configstr'), '-', '')]",
@@ -221,6 +228,7 @@
             ]
         },
         {
+            "condition": "[equals(parameters('enableReplica'), true())]",
             "apiVersion": "2017-05-10",
             "name": "[concat('sql-server','-', parameters('environmentNameAbbreviation'),'-replica')]",
             "type": "Microsoft.Resources/deployments",
@@ -361,6 +369,10 @@
                     }
                 }
             },
+            "dependsOn": [
+                "[concat('sql-server','-', parameters('environmentNameAbbreviation'))]",
+                "[concat('sql-server','-', parameters('environmentNameAbbreviation'),'-replica')]"
+            ],
             "copy": {
                 "count": "[length(variables('sqlServerNames'))]",
                 "name": "firewallrulecopy",

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -63,15 +63,16 @@
                 "description": ""
             }
         },
-        "sqlFirewallIpAddresses": {
+        "sqlFirewallIpAddressesPredefined": {
             "type": "array"
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/feature/TLD-295-add-replica-db/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/feature/TLD-295-rework-SQL-firewall-rules/ArmTemplates/",
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
         "sqlServerReplicaName": "[concat(variables('resourceNamePrefix'), '-shared-sql-replica')]",
+        "sqlServerNames": "[createArray(variables('sqlServerName'), variables('sqlServerReplicaName'))]",
         "sharedStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'sharedstr'), '-', '')]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-shared-asp')]",
         "configStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'configstr'), '-', '')]",
@@ -349,22 +350,16 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
-                    "firewallRuleNamePrefix": {
-                        "value": "[parameters('sqlFirewallIpAddresses')[copyIndex()].name]"
-                    },
-                    "startIpAddress": {
-                        "value": "[parameters('sqlFirewallIpAddresses')[copyIndex()].startIpAddress]"
-                    },
-                    "endIpAddress": {
-                        "value": "[parameters('sqlFirewallIpAddresses')[copyIndex()].endIpAddress]"
+                    "sqlFirewallIpAddressesPredefined": {
+                        "value": "[parameters('sqlFirewallIpAddressesPredefined')]"
                     },
                     "serverName": {
-                        "value": "[variables('sqlServerName')]"
+                        "value": "[variables('sqlServerNames')[copyIndex()]]"
                     }
                 }
             },
             "copy": {
-                "count": "[length(parameters('sqlFirewallIpAddresses'))]",
+                "count": "[length(variables('sqlServerNames'))]",
                 "name": "firewallrulecopy",
                 "mode": "Parallel"
             }

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -248,6 +248,9 @@
                     },
                     "threatDetectionEmailAddress": {
                         "value": "[parameters('threatDetectionEmailAddress')]"
+                    },
+                    "sqlStorageAccountName": {
+                        "value": "[variables('sharedStorageAccountName')]"
                     }
                 }
             },

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -11,6 +11,9 @@
         "sqlServerAdminPassword": {
             "type": "securestring"
         },
+        "sqlServerReplicaAdminPassword": {
+            "type": "securestring"
+        },
         "sqlServerActiveDirectoryAdminLogin": {
             "type": "string"
         },
@@ -65,9 +68,10 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/feature/TLD-295-add-replica-db/ArmTemplates/",
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
+        "sqlServerReplicaName": "[concat(variables('resourceNamePrefix'), '-shared-sql-replica')]",
         "sharedStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'sharedstr'), '-', '')]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-shared-asp')]",
         "configStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'configstr'), '-', '')]",
@@ -208,6 +212,41 @@
                     },
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[concat('shared-storage-account','-', parameters('environmentNameAbbreviation'))]"
+            ]
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "[concat('sql-server','-', parameters('environmentNameAbbreviation'),'-replica')]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'sql-server.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "sqlServerName": {
+                        "value": "[variables('sqlServerReplicaName')]"
+                    },
+                    "sqlServerAdminUserName": {
+                        "value": "[parameters('sqlServerAdminUsername')]"
+                    },
+                    "sqlServerAdminPassword": {
+                        "value": "[parameters('sqlServerReplicaAdminPassword')]"
+                    },
+                    "sqlServerActiveDirectoryAdminLogin": {
+                        "value": "[parameters('sqlServerActiveDirectoryAdminLogin')]"
+                    },
+                    "sqlServerActiveDirectoryAdminObjectId": {
+                        "value": "[parameters('sqlServerActiveDirectoryAdminObjectId')]"
+                    },
+                    "threatDetectionEmailAddress": {
+                        "value": "[parameters('threatDetectionEmailAddress')]"
                     }
                 }
             },

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -385,6 +385,10 @@
             "type": "string",
             "value": "[variables('sqlServerName')]"
         },
+        "sharedSQLServerReplicaName": {
+            "type": "string",
+            "value": "[variables('sqlServerReplicaName')]"
+        },
         "sharedStorageConnectionString": {
             "type": "string",
             "value": "[reference(concat('shared-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -267,6 +267,62 @@
             ]
         },
         {
+            "apiVersion": "2022-09-01",
+            "name": "[concat('key-vault-secret-',parameters('environmentNameAbbreviation'), '-admin-username', copyIndex())]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'keyvault-secret.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultName": {
+                        "value": "[variables('keyVaultName')]"
+                    },
+                    "secretName": {
+                        "value": "[concat(variables('sqlServerNames')[copyIndex()],'-admin-username')]"
+                    },
+                    "secretValue": {
+                        "value": "[parameters('sqlServerAdminUserName')]"
+                    }
+                }
+            },
+            "copy": {
+                "count": "[length(variables('sqlServerNames'))]",
+                "name": "firewallrulecopy",
+                "mode": "Parallel"
+            }
+        },
+        {
+            "apiVersion": "2022-09-01",
+            "name": "[concat('key-vault-secret-',parameters('environmentNameAbbreviation'), '-admin-password', copyIndex())]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'keyvault-secret.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultName": {
+                        "value": "[variables('keyVaultName')]"
+                    },
+                    "secretName": {
+                        "value": "[concat(variables('sqlServerNames')[copyIndex()],'-admin-password')]"
+                    },
+                    "secretValue": {
+                        "value": "[parameters('sqlServerAdminPassword')]"
+                    }
+                }
+            },
+            "copy": {
+                "count": "[length(variables('sqlServerNames'))]",
+                "name": "firewallrulecopy",
+                "mode": "Parallel"
+            }
+        },
+        {
             "apiVersion": "2017-05-10",
             "name": "[concat('app-service-plan','-', parameters('environmentNameAbbreviation'))]",
             "type": "Microsoft.Resources/deployments",

--- a/yaml/jobs/tlevels-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-infrastructure-job.yml
@@ -13,7 +13,7 @@ jobs:
       SharedASPName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedASPName'] ]
       SharedKeyVaultName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedKeyVaultName'] ]
       SharedSQLServerName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedSQLServerName'] ]
-      sharedSQLServerReplicaName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedSQLServerReplicaName'] ]
+      SharedSQLServerReplicaName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedSQLServerReplicaName'] ]
       ConfigurationStorageConnectionString: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.configStorageConnectionString'] ]
       SharedResourceGroup: $[stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.SharedVariables.SharedResourceGroup']]
 
@@ -41,7 +41,7 @@ jobs:
             -sharedEnvResourceGroup "$(SharedResourceGroup)"
             -sharedKeyVaultName "$(SharedKeyVaultName)"
             -sharedSQLServerName "$(SharedSQLServerName)"
-            -sharedSQLServerReplicaName "$(sharedSQLServerReplicaName)"
+            -sharedSQLServerReplicaName "$(SharedSQLServerReplicaName)"
             -sqlDatabaseSkuName "$(SQLDatabaseSkuName)"
             -sqlDatabaseTier "$(SQLDatabaseTier)"
             -sqlserverlessAutoPauseDelay "$(SQLServerlessAutoPauseDelay)"

--- a/yaml/jobs/tlevels-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-infrastructure-job.yml
@@ -59,7 +59,8 @@ jobs:
             -ucasTransferEntriesTrigger "$(ucasTransferEntriesTrigger)"
             -ucasTransferResultsTrigger "$(ucasTransferResultsTrigger)"
             -ucasTransferAmendmentsTrigger "$(ucasTransferAmendmentsTrigger)"
-            -overallResultCalculationTrigger "$(overallResultCalculationTrigger)"'
+            -overallResultCalculationTrigger "$(overallResultCalculationTrigger)"
+            -enableReplica $(enableReplica)'
           tags: $(Tags) 
           processOutputs: true
 

--- a/yaml/jobs/tlevels-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-infrastructure-job.yml
@@ -13,6 +13,7 @@ jobs:
       SharedASPName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedASPName'] ]
       SharedKeyVaultName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedKeyVaultName'] ]
       SharedSQLServerName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedSQLServerName'] ]
+      sharedSQLServerReplicaName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedSQLServerReplicaName'] ]
       ConfigurationStorageConnectionString: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.configStorageConnectionString'] ]
       SharedResourceGroup: $[stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.SharedVariables.SharedResourceGroup']]
 
@@ -40,6 +41,7 @@ jobs:
             -sharedEnvResourceGroup "$(SharedResourceGroup)"
             -sharedKeyVaultName "$(SharedKeyVaultName)"
             -sharedSQLServerName "$(SharedSQLServerName)"
+            -sharedSQLServerReplicaName "$(sharedSQLServerReplicaName)"
             -sqlDatabaseSkuName "$(SQLDatabaseSkuName)"
             -sqlDatabaseTier "$(SQLDatabaseTier)"
             -sqlserverlessAutoPauseDelay "$(SQLServerlessAutoPauseDelay)"

--- a/yaml/jobs/tlevels-shared-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-shared-infrastructure-job.yml
@@ -27,6 +27,7 @@ jobs:
                 armParameterOverrideString: '-environmentNameAbbreviation "${{parameters.baseName}}" 
                   -sqlServerAdminUsername "$(SQLServerAdminUsername)"
                   -sqlServerAdminPassword "$(SQLServerAdminPassword)"
+                  -sqlServerReplicaAdminPassword "$(sqlServerReplicaAdminPassword)"
                   -sqlServerActiveDirectoryAdminLogin "$(SQLServerActiveDirectoryAdminLogin)"
                   -sqlServerActiveDirectoryAdminObjectId "$(SQLServerActiveDirectoryAdminObjectId)"
                   -threatDetectionEmailAddress "$(ThreatDetectionEmailAddress)"

--- a/yaml/jobs/tlevels-shared-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-shared-infrastructure-job.yml
@@ -37,7 +37,7 @@ jobs:
                   -azureWebsitesRPObjectId "$(AzureWebsitesRPObjectId)"
                   -keyVaultReadWriteObjectIds "$(KeyVaultReadWriteObjectIds)"
                   -keyVaultFullAccessObjectIds "$(keyVaultFullAccessObjectIds)"
-                  -sqlFirewallIpAddresses $(sqlFirewallIpAddresses)'
+                  -sqlFirewallIpAddressesPredefined $(sqlFirewallIpAddresses)'
                 tags: $(Tags)
                 processOutputs: true
             - pwsh: Write-Host "##vso[task.setvariable variable=SharedResourceGroup;isOutput=true]$(SharedResourceGroup)"

--- a/yaml/jobs/tlevels-shared-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-shared-infrastructure-job.yml
@@ -37,7 +37,8 @@ jobs:
                   -azureWebsitesRPObjectId "$(AzureWebsitesRPObjectId)"
                   -keyVaultReadWriteObjectIds "$(KeyVaultReadWriteObjectIds)"
                   -keyVaultFullAccessObjectIds "$(keyVaultFullAccessObjectIds)"
-                  -sqlFirewallIpAddressesPredefined $(sqlFirewallIpAddresses)'
+                  -sqlFirewallIpAddressesPredefined $(sqlFirewallIpAddresses)
+                  -enableReplica $(enableReplica)'
                 tags: $(Tags)
                 processOutputs: true
             - pwsh: Write-Host "##vso[task.setvariable variable=SharedResourceGroup;isOutput=true]$(SharedResourceGroup)"

--- a/yaml/stages/tlevels-master-stage.yml
+++ b/yaml/stages/tlevels-master-stage.yml
@@ -1,16 +1,16 @@
 stages:
-  - template: tlevels-build-stage.yml
-    parameters:        
-      variableGroups:
-        - platform-global
-        - platform-global-resac
+  # - template: tlevels-build-stage.yml
+  #   parameters:        
+  #     variableGroups:
+  #       - platform-global
+  #       - platform-global-resac
 ######################## DEV ##############################################
   - template: tlevels-shared-stage.yml
     parameters:
       environmentTagName: Dev
       stageName: Dev
-      dependencies:
-        - build
+      # dependencies:
+      #   - build
       environmentName: dev
       sharedEnvironmentId: d01
       serviceConnection: $(devServiceConnection)
@@ -33,7 +33,7 @@ stages:
       environmentTagName: Test
       stageName: Test
       dependencies:
-        - build
+        - DeploySharedInfrastructure_d01
       environmentName: tst
       sharedEnvironmentId: t01
       serviceConnection: $(testServiceConnection)

--- a/yaml/stages/tlevels-master-stage.yml
+++ b/yaml/stages/tlevels-master-stage.yml
@@ -1,16 +1,16 @@
 stages:
-  # - template: tlevels-build-stage.yml
-  #   parameters:        
-  #     variableGroups:
-  #       - platform-global
-  #       - platform-global-resac
+  - template: tlevels-build-stage.yml
+    parameters:        
+      variableGroups:
+        - platform-global
+        - platform-global-resac
 ######################## DEV ##############################################
   - template: tlevels-shared-stage.yml
     parameters:
       environmentTagName: Dev
       stageName: Dev
-      # dependencies:
-      #   - build
+      dependencies:
+        - build
       environmentName: dev
       sharedEnvironmentId: d01
       serviceConnection: $(devServiceConnection)
@@ -33,7 +33,7 @@ stages:
       environmentTagName: Test
       stageName: Test
       dependencies:
-        - DeploySharedInfrastructure_d01
+        - build
       environmentName: tst
       sharedEnvironmentId: t01
       serviceConnection: $(testServiceConnection)


### PR DESCRIPTION
- Added resources and parameters required for deployment of a secondary replica server and database.
- Updated the apiVersion for the sql server firewall rule deployment resources. Required to allow a count of 0 to be processed.
- Updated sql firewall rules to deploy based on the number of sql servers.
- Passing of Key Vault name used for deployment of key vault secrets for the SQL credentials.