### PR TITLE
Adding Test 3 Environment and Required changes to build environment from scratch

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -204,6 +204,9 @@
                     },
                     "keyVaultResourceGroup": {
                         "value": "[parameters('sharedEnvResourceGroup')]"
+                    },
+                    "serverFarmId": {
+                        "value": "[resourceId(parameters('sharedEnvResourceGroup'),'Microsoft.Web/serverFarms',parameters('sharedASPName'))]"
                     }
                 }
             }
@@ -290,6 +293,9 @@
                     },
                     "keyVaultResourceGroup": {
                         "value": "[parameters('sharedEnvResourceGroup')]"
+                    },
+                    "serverFarmId": {
+                        "value": "[resourceId(parameters('sharedEnvResourceGroup'),'Microsoft.Web/serverFarms',parameters('sharedASPName'))]"
                     }
                 }
             }
@@ -377,6 +383,9 @@
                     },
                     "keyVaultResourceGroup": {
                         "value": "[parameters('sharedEnvResourceGroup')]"
+                    },
+                    "serverFarmId": {
+                        "value": "[resourceId(parameters('sharedEnvResourceGroup'),'Microsoft.Web/serverFarms',parameters('sharedASPName'))]"
                     }
                 }
             }

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -288,6 +288,9 @@
                     }
                 }
             },
+             "dependsOn": [
+                "[concat('key-vault','-', parameters('environmentNameAbbreviation'))]"
+            ],
             "copy": {
                 "count": "[length(variables('sqlServerNames'))]",
                 "name": "firewallrulecopy",
@@ -316,6 +319,9 @@
                     }
                 }
             },
+             "dependsOn": [
+                "[concat('key-vault','-', parameters('environmentNameAbbreviation'))]"
+            ],
             "copy": {
                 "count": "[length(variables('sqlServerNames'))]",
                 "name": "firewallrulecopy",

--- a/yaml/jobs/tlevels-integrationtest-job.yml
+++ b/yaml/jobs/tlevels-integrationtest-job.yml
@@ -20,11 +20,11 @@
     condition: eq('${{ parameters.environmentName }}', 'dev')
     
     variables:
+      SharedResourceGroup: $[stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.SharedVariables.SharedResourceGroup']]
       SharedSQLServerName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedSQLServerName'] ]
       ConfigurationStorageConnectionString: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.configStorageConnectionString'] ]
       IntTestSqlConnectionString: $[ dependencies.DeploySQLDatabase.outputs['IntTestSqlVariables.IntTestSqlConnectionString'] ]   
       EnvironmentName: ${{ upper(parameters.environmentName) }}
-
     steps:
     - script: echo $EnvironmentName
 
@@ -34,7 +34,7 @@
         downloadType: 'single'
         artifactName: 'sqldrop'
         downloadPath: '$(System.ArtifactsDirectory)'
-
+    
     - task: SqlAzureDacpacDeployment@1
       displayName: 'Azure SQL Dacpac - Integration Test'
       inputs:
@@ -69,6 +69,13 @@
         TokenStart: "__"
         TokenEnd: "__"
 
+    - task: AzureCLI@2
+      displayName: Create temporary SQL firewall rule to allow Azure service connections
+      inputs:
+        azureSubscription: ${{parameters.serviceConnection}}
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: 'az sql server firewall-rule create -g $(SharedResourceGroup) -s $(SharedSQLServerName) -n "allowAllAzure" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0'
 
     - task: VSTest@2
       displayName: 'Run Integration tests'
@@ -77,3 +84,11 @@
         searchFolder: '$(Agent.TempDirectory)\IntegrationTests'
         runInParallel: false
         failOnMinTestsNotRun: false
+
+    - task: AzureCLI@2
+      displayName: Remove temporary SQL firewall rule to allow Azure service connections
+      inputs:
+        azureSubscription: ${{parameters.serviceConnection}}
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: 'az sql server firewall-rule delete -g $(SharedResourceGroup) -s $(SharedSQLServerName) -n "allowAllAzure"'

--- a/yaml/stages/tlevels-master-stage.yml
+++ b/yaml/stages/tlevels-master-stage.yml
@@ -51,6 +51,30 @@ stages:
       serviceConnection: $(testServiceConnection)
       applicationName: resac
 
+######################## TEST 3 ##############################################
+  - template: tlevels-shared-stage.yml
+    parameters:
+      environmentTagName: Test3
+      stageName: Test3
+      dependencies:
+        - build
+      environmentName: tst3
+      sharedEnvironmentId: t03
+      serviceConnection: $(testServiceConnection)
+      applicationName: resac
+    
+  - template: tlevels-stage.yml
+    parameters:
+      environmentTagName: Test3
+      stageName: Test3
+      dependencies:
+        - DeploySharedInfrastructure_t03
+      environmentName: tst3
+      environmentId: t03
+      sharedEnvironmentId: t03
+      serviceConnection: $(testServiceConnection)
+      applicationName: resac
+
 ######################## Pre Prod ##############################################
   - template: tlevels-shared-stage.yml
     parameters:


### PR DESCRIPTION
This PR includes the changes required for building an environment from scratch and adding Test3 to our pipeline.

it also includes:
[added rule to temporary allow azure connections to SQL server](https://github.com/SkillsFundingAgency/tl-results-and-certification/commit/3e47cd70931afaec8b1740cc178ac1edfa1150c0)
Which is needed for the unit testing to succeed in the development stage.