### PR TITLE
added allow all azure temp firewall rule

### DIFF
--- a/yaml/jobs/tlevels-publish-dacpac-job.yml
+++ b/yaml/jobs/tlevels-publish-dacpac-job.yml
@@ -12,6 +12,7 @@ jobs:
     - DeployInfrastructure 
 
   variables:
+    SharedResourceGroup: $[stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.SharedVariables.SharedResourceGroup']]
     SharedSQLServerName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedSQLServerName'] ]
     DatabaseName: $[ dependencies.DeployInfrastructure.outputs['armOutputs.armOutput.sqlDatabaseName'] ]
     IntTestDatabaseName: $[ dependencies.DeployInfrastructure.outputs['armOutputs.armOutput.IntTestSQLDatabaseName'] ]
@@ -22,7 +23,15 @@ jobs:
         downloadType: 'single'
         artifactName: 'sqldrop'
         downloadPath: '$(System.ArtifactsDirectory)'
-   
+
+    - task: AzureCLI@2
+      displayName: Create temporary SQL firewall rule to allow Azure service connections
+      inputs:
+        azureSubscription: ${{parameters.serviceConnection}}
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: 'az sql server firewall-rule create -g $(SharedResourceGroup) -s $(SharedSQLServerName) -n "allowAllAzure" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0'
+
     - task: SqlAzureDacpacDeployment@1
       displayName: 'Azure SQL Publish'
       inputs:
@@ -33,6 +42,14 @@ jobs:
         SqlPassword: '$(SQLServerAdminPassword)'
         DacpacFile: '$(System.ArtifactsDirectory)/sqldrop/src/Sfa.Tl.ResultsAndCertification.Database/bin/Release/Sfa.Tl.ResultsAndCertification.Database.dacpac'
         AdditionalArguments: '/p:GenerateSmartDefaults=True /v:environment=$(sqlPublishEnvironmentName)'
+
+    - task: AzureCLI@2
+      displayName: Remove temporary SQL firewall rule to allow Azure service connections
+      inputs:
+        azureSubscription: ${{parameters.serviceConnection}}
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: 'az sql server firewall-rule delete -g $(SharedResourceGroup) -s $(SharedSQLServerName) -n "allowAllAzure"'
 
     - pwsh: | 
         $SqlConnectionString = "Server=tcp:$(SharedSQLServerName).database.windows.net,1433;Database=$(DatabaseName);User ID=$(ResacSQLServiceAccountUsername);Password=$(ResacSQLServiceAccountPassword);Trusted_Connection=False;Pooling=True;Connect Timeout=30;MultipleActiveResultSets=True"


### PR DESCRIPTION
Added rule to pipeline to allow all azure IP addresses during the publish dacpac task and removing once the task has been completed