### PR TITLE
Rotate Storage Account Access Keys

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -476,15 +476,15 @@
                             },
                             {
                                 "name": "BlobStorageConnectionString",
-                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
                             },
                             {
                                 "name": "AzureWebJobsStorage",
-                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
                             },
                             {
                                 "name": "AzureWebJobsDashboard",
-                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
                             },
                             {
                                 "name": "WEBSITE_TIME_ZONE",
@@ -731,7 +731,7 @@
         },
         "BlobStorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         }
     }
 }

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -465,11 +465,11 @@
         },
         "sharedStorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('shared-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('shared-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         },
         "configStorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('config-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('config-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         },
         "ConfigStorageAccountName": {
             "type": "string",


### PR DESCRIPTION
This change updates storage account access key outputs in the ARM templates to support the rotation of the keys, by consuming the newly created key2 connection string output that is being constructed in the platform building blocks repository.