### PR TITLE
Rotate access keys for SQL audit logs

### DIFF
--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -224,12 +224,6 @@
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
                     },
-                    "sqlStorageAccountAccessKey1": {
-                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey1.value]"
-                    },
-                    "sqlStorageAccountAccessKey2": {
-                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey2.value]"
-                    },
                     "isStorageSecondaryKeyInUse": {
                         "value": "[true()]"
                     }
@@ -271,12 +265,6 @@
                     },
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
-                    },
-                    "sqlStorageAccountAccessKey1": {
-                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey1.value]"
-                    },
-                    "sqlStorageAccountAccessKey2": {
-                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey2.value]"
                     },
                     "isStorageSecondaryKeyInUse": {
                         "value": "[true()]"

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -75,7 +75,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/feature/TLD-351-access-key-rotation-for-SQL/ArmTemplates/",
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
         "sqlServerReplicaName": "[concat(variables('resourceNamePrefix'), '-shared-sql-replica')]",

--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -223,6 +223,15 @@
                     },
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    },
+                    "sqlStorageAccountAccessKey1": {
+                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey1.value]"
+                    },
+                    "sqlStorageAccountAccessKey2": {
+                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey2.value]"
+                    },
+                    "isStorageSecondaryKeyInUse": {
+                        "value": "[true()]"
                     }
                 }
             },
@@ -262,6 +271,15 @@
                     },
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    },
+                    "sqlStorageAccountAccessKey1": {
+                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey1.value]"
+                    },
+                    "sqlStorageAccountAccessKey2": {
+                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey2.value]"
+                    },
+                    "isStorageSecondaryKeyInUse": {
+                        "value": "[true()]"
                     }
                 }
             },


### PR DESCRIPTION
This change adds references for key1 and key2 for the storage account for the audit logs. Additionally, it sets the current key being used to key2. This change is also applied to the replica SQL server.