### PR TITLE
Rotate access keys for SQL audit log storage

### DIFF
--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -72,6 +72,10 @@
             "metadata": {
                 "description": "Enables the replica database to be deployed"
             }
+        },
+        "isStorageSecondaryKeyInUse": {
+            "type": "bool",
+            "allowedValues": [ true, false ]
         }
     },
     "variables": {
@@ -223,6 +227,9 @@
                     },
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    },
+                    "isStorageSecondaryKeyInUse": {
+                        "value": "[parameters('isStorageSecondaryKeyInUse')]"
                     }
                 }
             },
@@ -262,6 +269,9 @@
                     },
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    },
+                    "isStorageSecondaryKeyInUse": {
+                        "value": "[parameters('isStorageSecondaryKeyInUse')]"
                     }
                 }
             },

--- a/yaml/jobs/tlevels-shared-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-shared-infrastructure-job.yml
@@ -38,7 +38,8 @@ jobs:
                   -keyVaultReadWriteObjectIds "$(KeyVaultReadWriteObjectIds)"
                   -keyVaultFullAccessObjectIds "$(keyVaultFullAccessObjectIds)"
                   -sqlFirewallIpAddressesPredefined $(sqlFirewallIpAddresses)
-                  -enableReplica $(enableReplica)'
+                  -enableReplica $(enableReplica)
+                  -isStorageSecondaryKeyInUse "$(isStorageSecondaryKeyInUse)"'
                 tags: $(Tags)
                 processOutputs: true
             - pwsh: Write-Host "##vso[task.setvariable variable=SharedResourceGroup;isOutput=true]$(SharedResourceGroup)"


### PR DESCRIPTION
These changes add a parameter "isStorageSecondaryKeyInUse", which is stored as a variable within Azure DevOps variable groups, per service & per environment (**platform-dev-resac** for example). This can be used to switch between using key1 or key2 when storing SQL audit logs to a storage account.