### PR TITLE
added app setting to restrict when swap slot occurs

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -297,6 +297,10 @@
                             {
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
                                 "value": "[reference(concat('app-insights','-',parameters('environmentNameAbbreviation'))).outputs.InstrumentationKey.value]"
+                            },
+                            {
+                                "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",
+                                "value": "200"
                             }
                         ]
                     },
@@ -386,6 +390,10 @@
                             {
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
                                 "value": "[reference(concat('app-insights','-',parameters('environmentNameAbbreviation'))).outputs.InstrumentationKey.value]"
+                            },
+                            {
+                                "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",
+                                "value": "200, 404"
                             }
                         ]
                     },


### PR DESCRIPTION
Added WEBSITE_SWAP_WARMUP_PING_STATUSES to restrict when swap slot can occur.

Front-end: Occurs if a 200 is returned
Internal API: Occurs if a 404 is returned (This is because we don't have a health check page setup, once a health check page is setup the 404 should be removed and the setting should be set to 200 and/or 202)

Function App: The app setting doesn't work on the function app due to it not being able to determine the status from the default azure function page. A custom health check page should be implemented to resolve