### PR TITLE
Added app settings for successful swap slots

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -297,6 +297,10 @@
                             {
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
                                 "value": "[reference(concat('app-insights','-',parameters('environmentNameAbbreviation'))).outputs.InstrumentationKey.value]"
+                            },
+                            {
+                                "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",
+                                "value": "200"
                             }
                         ]
                     },
@@ -379,13 +383,21 @@
                                 "name": "Version",
                                 "value": "1.0"
                             },
-                            {
+                            {                       
                                 "name": "ServiceName",
                                 "value": "Sfa.Tl.ResultsAndCertification"
                             },
                             {
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
                                 "value": "[reference(concat('app-insights','-',parameters('environmentNameAbbreviation'))).outputs.InstrumentationKey.value]"
+                            },
+                            {
+                                "name": "WEBSITE_SWAP_WARMUP_PING_PATH",
+                                "value": "/api/tlevel/VerifyTLevel"
+                            },
+                            {
+                                "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",
+                                "value": "405"
                             }
                         ]
                     },


### PR DESCRIPTION
- Added WEBSITE_SWAP_WARMUP_PING_STATUSES to ping the home page of the front end, swap slot will only occur if 200 occurs.
- Added WEBSITE_SWAP_WARMUP_PING_STATUSES  and WEBSITE_SWAP_WARMUP_PING_PATH to test an internal API path, this should return 405 if the API is running. (This is a temporary solution)