### PR TITLE
Add Blob Storage Lifecycle Policy

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -127,6 +127,9 @@
       "metadata": {
         "description": "Enables the integration test database to be deployed"
       }
+    },
+    "containerLifecyclePolicyRules": {
+      "type": "array"
     }
   },
   "variables": {
@@ -736,7 +739,28 @@
           }
         }
       }
+    },
+{
+  "apiVersion": "2022-09-01",
+  "name": "[concat('storage-account-lifecycle-policy','-', parameters('environmentNameAbbreviation'))]",
+  "resourceGroup": "[resourceGroup().name]",
+  "type": "Microsoft.Resources/deployments",
+  "properties": {
+    "mode": "Incremental",
+    "templateLink": {
+      "uri": "[concat(variables('deploymentUrlBase'),'storage-management-policy.json')]",
+      "contentVersion": "1.0.0.0"
+    },
+    "parameters": {
+      "storageAccountName": {
+        "value": "[variables('storageAccountName')]"
+      },
+      "policyRules": {
+        "value": "[parameters('containerLifecyclePolicyRules')]"
+      }
     }
+  }
+}
   ],
   "outputs": {
     "sqlDatabaseName": {

--- a/yaml/jobs/tlevels-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-infrastructure-job.yml
@@ -25,6 +25,7 @@ jobs:
           'Write-Host "SharedKeyVaultName variable: $(SharedKeyVaultName)"'
           'Write-Host "SharedSQLServerName variable: $(SharedSQLServerName)"'
           'Write-Host "ConfigurationStorageConnectionString variable: $(ConfigurationStorageConnectionString)"'
+          'Write-Host "containerLifecyclePolicyRules variable: $(containerLifecyclePolicyRules)"'
         displayName: "Show Variables"
 
       - template: ./Infrastructure/steps/deploy-template.yml@devopsTemplates
@@ -66,7 +67,8 @@ jobs:
             -specialismRommExtractTrigger "$(specialismRommExtractTrigger)"
             -providerAddressExtractTrigger "$(providerAddressExtractTrigger)"
             -CertificateTrackingExtractTrigger "$(CertificateTrackingExtractTrigger)"
-            -enableReplica $(enableReplica)'
+            -enableReplica $(enableReplica)
+            -containerLifecyclePolicyRules $(containerLifecyclePolicyRules)'
           tags: $(Tags) 
           processOutputs: true
 


### PR DESCRIPTION
This feature adds a lifecycle policy rule that will remove data extracts after a certain amount of time has passed. The days before deletion is controlled by a variable called "LifecycleRemovalPolicyDaysAfterModification" which can be found in pipeline variable groups, and the rest of the policy config that specifies what files are to be deleted are stored in the pipeline-templates repository.