### PR TITLE
Disable managed identity access for audit settings

### DIFF
--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -232,7 +232,7 @@
                         "value": "[parameters('isStorageSecondaryKeyInUse')]"
                     },
                     "isManagedIdentityInUse":{
-                        "value": true
+                        "value": false
                     }
                 }
             },


### PR DESCRIPTION
Hotfix to disable the use of managed identity to log the audit settings