### PR TITLE
Add app service IP restrictions

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -133,6 +133,9 @@
     },
     "configStorageAccountName": {
       "type": "string"
+    },
+    "ipSecurityRestrictions": {
+      "type": "array"
     }
   },
   "variables": {
@@ -329,6 +332,12 @@
           },
           "certificateThumbprint": {
             "value": "[if(greater(length(parameters('uiCustomHostname')), 0), reference(concat('ui-app-service-certificate','-', parameters('environmentNameAbbreviation')), '2018-11-01').outputs.certificateThumbprint.value, '')]"
+          },
+          "ipSecurityRestrictions": {
+            "value": "[parameters('ipSecurityRestrictions')]"
+          },
+          "ipSecurityRestrictionsDefaultAction": {
+            "value": "Deny"
           }
         }
       },
@@ -426,6 +435,12 @@
           },
           "certificateThumbprint": {
             "value": "[if(greater(length(parameters('internalApiCustomHostname')), 0), reference(concat('internal-api-app-service-certificate','-',parameters('environmentNameAbbreviation')), '2018-11-01').outputs.certificateThumbprint.value, '')]"
+          },
+          "ipSecurityRestrictions": {
+            "value": "[parameters('ipSecurityRestrictions')]"
+          },
+          "ipSecurityRestrictionsDefaultAction": {
+            "value": "Deny"
           }
         }
       },

--- a/yaml/jobs/tlevels-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-infrastructure-job.yml
@@ -70,7 +70,8 @@ jobs:
             -providerAddressExtractTrigger "$(providerAddressExtractTrigger)"
             -CertificateTrackingExtractTrigger "$(CertificateTrackingExtractTrigger)"
             -enableReplica $(enableReplica)
-            -containerLifecyclePolicyRules $(containerLifecyclePolicyRules)'
+            -containerLifecyclePolicyRules $(containerLifecyclePolicyRules)
+            -ipSecurityRestrictions $(ipSecurityRestrictions)'
           tags: $(Tags) 
           processOutputs: true
 

--- a/yaml/stages/tlevels-master-stage.yml
+++ b/yaml/stages/tlevels-master-stage.yml
@@ -27,6 +27,9 @@ stages:
       sharedEnvironmentId: d01
       serviceConnection: $(devServiceConnection)
       applicationName: resac
+      variableTemplates: 
+        - ./Automation/variables/vars-non-prd.yml@devopsTemplates
+
 ######################## TEST ##############################################
   - template: tlevels-shared-stage.yml
     parameters:
@@ -50,6 +53,8 @@ stages:
       sharedEnvironmentId: t01
       serviceConnection: $(testServiceConnection)
       applicationName: resac
+      variableTemplates: 
+        - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 
 ######################## TEST 3 ##############################################
   - template: tlevels-shared-stage.yml
@@ -74,7 +79,9 @@ stages:
       sharedEnvironmentId: t03
       serviceConnection: $(testServiceConnection)
       applicationName: resac
-
+      variableTemplates: 
+        - ./Automation/variables/vars-non-prd.yml@devopsTemplates
+      
 ######################## Pre Prod ##############################################
   - template: tlevels-shared-stage.yml
     parameters:
@@ -99,6 +106,8 @@ stages:
       sharedEnvironmentId: p02
       serviceConnection: $(prodServiceConnection)
       applicationName: resac
+      variableTemplates: 
+        - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 
 ########################## Prod ##############################################
   - template: tlevels-shared-stage.yml
@@ -124,3 +133,5 @@ stages:
       sharedEnvironmentId: p01
       serviceConnection: $(prodServiceConnection)
       applicationName: resac
+      variableTemplates: 
+        - ./Automation/variables/vars-prd.yml@devopsTemplates

--- a/yaml/stages/tlevels-stage.yml
+++ b/yaml/stages/tlevels-stage.yml
@@ -16,6 +16,9 @@ parameters:
     type: string
   - name: applicationName
     type: string
+  - name: variableTemplates
+    type: object  
+
 stages:
   - stage: Deploy_${{parameters.environmentId}}
     dependsOn:
@@ -33,6 +36,8 @@ stages:
         value: ${{ parameters.environmentName }}
       - name: environmentTagName
         value: ${{parameters.environmentTagName}}
+      - '${{ each variableTemplate in parameters.variableTemplates }}':
+        - template: '${{variableTemplate}}'       
 
     displayName: "${{parameters.environmentName}} [${{parameters.environmentId}}] deployment"
     jobs:


### PR DESCRIPTION
Adds app service IP restrictions to only allow traffic from the prod or non prod WAF by taking the restriction rules from yaml templates, and setting the default action for unrecognised traffic to be deny.