### PR TITLE
Move KV Soft Delete to Template

### DIFF
--- a/azure/tlevels-shared.json
+++ b/azure/tlevels-shared.json
@@ -429,9 +429,6 @@
                     "enabledForTemplateDeployment": {
                         "value": true
                     },
-                    "enableSoftDelete": {
-                        "value": true
-                    },
                     "keyVaultAccessPolicies": {
                         "value": "[concat(variables('keyVaultAccessPolicies'), variables('readWriteAccessPolicies').readWriteAccessPolicies, variables('fullAccessPolicies').fullAccessPolicies)]"
                     }


### PR DESCRIPTION
This change is being done to ensure KV soft delete is configured at the template level. The related update to the platform building blocks repo can be found here: https://github.com/SkillsFundingAgency/tl-platform-building-blocks/pull/47