### PR TITLE
Fetch Internal API IP Restrictions

### DIFF
--- a/azure/tlevels-environment.json
+++ b/azure/tlevels-environment.json
@@ -136,6 +136,10 @@
     },
     "ipSecurityRestrictions": {
       "type": "array"
+    },
+    "internalApiIpSecurityRestrictions": {
+      "type": "array",
+      "defaultValue": []
     }
   },
   "variables": {
@@ -452,10 +456,13 @@
             "value": "[if(greater(length(parameters('internalApiCustomHostname')), 0), reference(concat('internal-api-app-service-certificate','-',parameters('environmentNameAbbreviation')), '2018-11-01').outputs.certificateThumbprint.value, '')]"
           },
           "ipSecurityRestrictionsDefaultAction": {
-            "value": "Allow"
+            "value": "Deny"
           },
           "healthCheckPath": {
             "value": "/health"
+          },
+          "ipSecurityRestrictions": {
+            "value": "[parameters('internalApiIpSecurityRestrictions')]"
           }
         }
       },

--- a/yaml/jobs/tlevels-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-infrastructure-job.yml
@@ -19,7 +19,7 @@ jobs:
       SharedResourceGroup: $[stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.SharedVariables.SharedResourceGroup']]
       EntraReaderUserIdentityResourceId: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.EntraReaderUserIdentityResourceId'] ]
       SqlUserIdentityResourceId: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.SqlUserIdentityResourceId'] ]
-  
+
     steps:
       - checkout: self
       - checkout: devopsTools
@@ -31,6 +31,16 @@ jobs:
           'Write-Host "ConfigurationStorageConnectionString variable: $(ConfigurationStorageConnectionString)"'
           'Write-Host "containerLifecyclePolicyRules variable: $(containerLifecyclePolicyRules)"'
         displayName: "Show Variables"
+    
+      - task: AzureCLI@2
+        displayName: 'Fetch Internal API IP Security Restrictions'
+        inputs:
+          azureSubscription: ${{parameters.serviceConnection}}
+          scriptType: 'pscore'
+          scriptLocation: 'ScriptPath'
+          ScriptPath: ./operations-devops-tools/Powershell/AppServiceRestrictions/FetchIpSecurityRestrictions.ps1
+          ScriptArguments: '-resourceGroupName $(BaseName) -appServiceName $(InternalAPIAppServiceName)'
+          azurePowerShellVersion: 'LatestVersion'
 
       - task: AzureCLI@2
         displayName: Create temporary SQL firewall rule to allow Azure service connections
@@ -82,7 +92,8 @@ jobs:
             -CertificateTrackingExtractTrigger "$(CertificateTrackingExtractTrigger)"
             -enableReplica $(enableReplica)
             -containerLifecyclePolicyRules $(containerLifecyclePolicyRules)
-            -ipSecurityRestrictions $(ipSecurityRestrictions)'
+            -ipSecurityRestrictions $(ipSecurityRestrictions)
+            -internalApiIpSecurityRestrictions $(internalApiIpSecurityRestrictions)'
           tags: $(Tags) 
           processOutputs: true
       


### PR DESCRIPTION
This PR introduces functionality to check the existing IP restrictions applied to the internal API app service and ensure they are preserved during infrastructure deployments. Unlike the front-end app service, the internal API requires a dynamic range of IP addresses, which may change over time. This means that the same config and rules for the front-end app service restrictions cannot be used.

**Changes:**

- Pipeline task added to fetch the current IP restrictions for the internal API before deployment.
- IP restriction default action set to deny (this is also applied during the nightly pipeline run.