### PR TITLE
Cache NuGet Packages

### DIFF
--- a/yaml/jobs/tlevels-build-application-job.yml
+++ b/yaml/jobs/tlevels-build-application-job.yml
@@ -1,5 +1,7 @@
 jobs:
 - job: 'CodeBuild'
+  variables:
+    NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
   pool:
       name: 'Azure Pipelines'
       vmImage: 'windows-latest' #'vs2017-win2016'
@@ -41,12 +43,21 @@ jobs:
         packageType: 'sdk'
         version: '6.x'
 
+    - task: Cache@2
+      displayName: Cache
+      inputs:
+        key: 'nuget | "$(Agent.OS)" | src\Sfa.Tl.ResultsAndCertification.Web\package-lock.json'
+        restoreKeys: |
+          nuget | "$(Agent.OS)"
+          nuget
+        path: '$(NUGET_PACKAGES)'
+        cacheHitVar: 'CACHE_RESTORED'
+  
     - task: DotNetCoreCLI@2
       displayName: Restore
       inputs:
         command: restore
         projects: 'src/Sfa.Tl.ResultsAndCertification.sln' 
-        noCache: true
 
     - task: DotNetCoreCLI@2
       displayName: Build


### PR DESCRIPTION
This PR adds caching for NuGet packages which improves build performance by reducing redundant package restores.

**Changes:**

- Added task to cache NuGet packages using package-lock.json as the cache key.
- Defined NUGET_PACKAGES variable for the cache path.
- Removed noCache: true from the restore task to enable dependency caching.