### PR TITLE
Update GitVersion

### DIFF
--- a/yaml/jobs/tlevels-build-application-job.yml
+++ b/yaml/jobs/tlevels-build-application-job.yml
@@ -14,12 +14,6 @@ jobs:
       inputs:
         packageType: 'sdk'
         version: '2.1.x'
-        
-    - task: GitVersion@5
-      displayName: GitVersion
-      inputs:
-        runtime: 'core'
-        updateAssemblyInfo: true
     
     - task: NodeTool@0
       inputs:
@@ -42,6 +36,16 @@ jobs:
       inputs:
         packageType: 'sdk'
         version: '6.x'
+
+    - task: gitversion/setup@3.1.1
+      displayName: Install GitVersion
+      inputs:
+        versionSpec: '6.0.x'
+
+    - task: gitversion/execute@3.1.1
+      displayName: Update GitVersion
+      inputs:
+        updateAssemblyInfo: true
 
     - task: Cache@2
       displayName: Cache


### PR DESCRIPTION
Updates GitVersion to use GitTools due to the former being dependent on a version of Node that is now EoL.