### PR TITLE
Add Key Vault Config Automation to Pipeline

### DIFF
--- a/yaml/jobs/tlevels-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-infrastructure-job.yml
@@ -130,5 +130,11 @@ jobs:
           scriptLocation: 'inlineScript'
           inlineScript: 'az sql server firewall-rule delete -g $(SharedResourceGroup) -s $(SharedSQLServerName) -n "allowAllAzure"'
 
-
-     
+      - task: AzurePowerShell@5
+        displayName: 'Set Certificate Policy'
+        inputs:
+          azureSubscription: ${{ parameters.serviceConnection }}
+          ScriptType: InlineScript
+          Inline: | 
+            Set-AzKeyVaultCertificatePolicy -VaultName $(SharedKeyVaultName) -Name $(CertificateName) -RenewAtNumberOfDaysBeforeExpiry 30
+          azurePowerShellVersion: LatestVersion

--- a/yaml/jobs/tlevels-shared-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-shared-infrastructure-job.yml
@@ -7,6 +7,8 @@ parameters:
     type: string
   - name: environmentName
     type: string
+  - name: globalSignServiceAccountPassword
+    type: string
 jobs:
 
   - deployment: DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}
@@ -17,13 +19,14 @@ jobs:
         deploy:
           steps:
             - checkout: self
+            - checkout: devopsTools
             - template: ./Infrastructure/steps/deploy-template.yml@devopsTemplates
               parameters:
                 serviceConnection: ${{ parameters.serviceConnection }}
                 subscriptionId: $(subscriptionId)
                 resourceGroupName: $(SharedResourceGroup)
                 location: 'West Europe'
-                templateFilePath: './azure/tlevels-shared.json'
+                templateFilePath: './tl-results-and-certification/azure/tlevels-shared.json'
                 armParameterOverrideString: '-environmentNameAbbreviation "${{parameters.baseName}}" 
                   -sqlServerAdminUsername "$(SQLServerAdminUsername)"
                   -sqlServerAdminPassword "$(SQLServerAdminPassword)"
@@ -75,3 +78,15 @@ jobs:
                   Write-Host "##vso[task.setvariable variable=DataProtectionKeyVaultKeyId;isOutput=true]$($KeyId)"                  
                 azurePowerShellVersion: LatestVersion
                 pwsh: true
+
+            - task: AzurePowerShell@5
+              displayName: 'Set Certificate Issuer and Contacts'
+              inputs:
+                azureSubscription: ${{ parameters.serviceConnection }}
+                ScriptType: 'FilePath'
+                ScriptPath: './operations-devops-tools/Powershell/SetKeyVaultConfig/SetKeyVaultConfig.ps1'
+                ScriptArguments: '-SharedKeyVaultName "$(armOutputs.armoutput.sharedKeyVaultName)" -GlobalSignServiceAccountId $(GlobalSignServiceAccountId) -KvContactEmailAddress $(KvContactEmailAddress) -CaAdminFirstName $(CaAdminFirstName) -CaAdminLastName $(CaAdminLastName) -CaAdminEmailAddress $(CaAdminEmailAddress)'
+                FailOnStandardError: true
+                azurePowerShellVersion: LatestVersion
+              env: 
+                globalSignServiceAccountPassword: $(GlobalSignServiceAccountPassword)

--- a/yaml/stages/tlevels-shared-stage.yml
+++ b/yaml/stages/tlevels-shared-stage.yml
@@ -24,6 +24,7 @@ stages:
     - group: platform-global-${{parameters.applicationName}}
     - group: platform-${{parameters.environmentName}}
     - group: platform-${{parameters.environmentName}}-${{parameters.applicationName}}
+    - group: platform-global
     - name: SharedBaseName
       value: "s126${{parameters.sharedEnvironmentId}}-${{parameters.applicationName}}"
     - name: SharedResourceGroup
@@ -43,3 +44,4 @@ stages:
       serviceConnection: ${{ parameters.serviceConnection }}
       sharedEnvironmentId: ${{ parameters.sharedEnvironmentId }}
       environmentName: ${{parameters.environmentName}}
+      globalSignServiceAccountPassword: $($GlobalSignServiceAccountPassword)


### PR DESCRIPTION
This pull request adds tasks to automate the configuration of Key Vault certificates and issuer settings.

**Changes**


- Adds a task to configure the certificate issuer/CA and contact information for Key Vault by utilising a PowerShell script from the DevOps Tools repo (https://github.com/DFE-Digital/operations-devops-tools/pull/31)
- Adds a task to update the certificate renewal policy for certificates to auto renew at 30 days expiry