### PR TITLE
Update Generate Config Task

### DIFF
--- a/yaml/jobs/tlevels-generate-configs-job.yml
+++ b/yaml/jobs/tlevels-generate-configs-job.yml
@@ -6,6 +6,11 @@ parameters:
   - name: tableName
     type: string
     default: "configuration"
+  - name: environmentName
+    type: string
+  - name: ConfigurationSecrets
+    type: object
+    default: {}
 jobs:
   - job: GenerateConfigs
     variables:
@@ -25,6 +30,8 @@ jobs:
       - DeploySQLDatabase
 
     steps:
+      - checkout: self
+      - checkout: devopsTools
       - task: DownloadBuildArtifacts@0
         inputs:
           buildType: "current"
@@ -32,10 +39,20 @@ jobs:
           artifactName: "appdrop"
           downloadPath: "$(System.ArtifactsDirectory)"
 
-      - task: GenerateEnvironmentConfiguration@3
-        displayName: "Process schemas in $(System.ArtifactsDirectory)/appdrop/config"
+      - task: AzurePowerShell@5
+        displayName: 'Generate Configuration'
         inputs:
-          SourcePath: "$(System.ArtifactsDirectory)/appdrop/config"
-          ServiceConnectionName: ${{ parameters.serviceConnection}}
-          StorageAccountName: "$(ConfigStorageAccountName)"
-          TableName: Configuration
+          azureSubscription: ${{ parameters.ServiceConnection }}
+          ScriptType: 'FilePath'
+          scriptPath: './operations-devops-tools/Powershell/GenerateConfig/New-ConfigurationTableEntry.ps1'
+          scriptArguments:
+            -SourcePath "$(System.ArtifactsDirectory)/appdrop/config"
+            -TargetFilename "Sfa.Tl.ResultsAndCertification.schema.json"
+            -StorageAccountName "$(ConfigStorageAccountName)"
+            -StorageAccountResourceGroup "$(SharedResourceGroup)"
+            -EnvironmentName ${{ parameters.EnvironmentName }}
+            -TableName "Configuration"
+          azurePowerShellVersion: LatestVersion
+          pwsh: true
+          FailOnStandardError: true
+        env: ${{ parameters.ConfigurationSecrets }}

--- a/yaml/stages/tlevels-stage.yml
+++ b/yaml/stages/tlevels-stage.yml
@@ -37,7 +37,11 @@ stages:
       - name: environmentTagName
         value: ${{parameters.environmentTagName}}
       - '${{ each variableTemplate in parameters.variableTemplates }}':
-        - template: '${{variableTemplate}}'       
+        - template: '${{variableTemplate}}'
+      - name: SharedBaseName
+        value: "s126${{parameters.sharedEnvironmentId}}-${{parameters.applicationName}}"
+      - name: SharedResourceGroup
+        value: '$(SharedBaseName)-shared'     
 
     displayName: "${{parameters.environmentName}} [${{parameters.environmentId}}] deployment"
     jobs:
@@ -57,6 +61,24 @@ stages:
         parameters:
           serviceConnection: ${{ parameters.serviceConnection }}
           sharedEnvironmentId: ${{ parameters.sharedEnvironmentId }}
+          environmentName: ${{ parameters.environmentName }}
+          ConfigurationSecrets: 
+            BlobStorageAccountKey: $(BlobStorageAccountKey)
+            ConfigStorageAccountkey: $(ConfigStorageAccountkey)
+            ConfigurationStorageConnectionString: $(ConfigurationStorageConnectionString)
+            DfeSignInApiSecret: $(DfeSignInApiSecret)
+            DfeSignInClientSecret: $(DfeSignInClientSecret)
+            GovUkNotifyApiKey: $(GovUkNotifyApiKey)
+            LearningRecordServicePassword: $(LearningRecordServicePassword)
+            OrdnanceSurveyPlacesApiPlacesKey: $(OrdnanceSurveyPlacesApiPlacesKey)
+            PrintingApiPassword: $(PrintingApiPassword)
+            RedisCacheConnection: $(RedisCacheConnection)
+            RedisCachePassword: $(RedisCachePassword)
+            ResacSQLServiceAccountPassword: $(ResacSQLServiceAccountPassword)
+            SharedStorageAccountKey: $(SharedStorageAccountKey)
+            SQLServerAdminPassword: $(SQLServerAdminPassword)
+            sqlServerReplicaAdminPassword: $(sqlServerReplicaAdminPassword)
+            UcasApiPassword: $(UcasApiPassword)
 
       - template: ../jobs/tlevels-integrationtest-job.yml
         parameters:


### PR DESCRIPTION
The old custom pipeline task which generates application config was using depreciated PowerShell modules, so the task has been replaced with PowerShell scripts. The scripts have pulled directly from AS and have only had a small modification to ensure the required modules are installed due to T Levels not using custom images for the self-hosted agents.

PR for the scripts being added can be found here: https://github.com/DFE-Digital/operations-devops-tools/pull/32