### PR TITLE
Update Variable Config for KV Secret Migration

### DIFF
--- a/config/Sfa.Tl.ResultsAndCertification.schema.json
+++ b/config/Sfa.Tl.ResultsAndCertification.schema.json
@@ -79,26 +79,6 @@
       ],
       "type": "object"
     },
-    "BlobStorageSettings": {
-      "properties": {
-        "AccountName": {
-          "minLength": 1,
-          "type": "string",
-          "environmentVariable": "BlobStorageAccountName"
-        },
-        "AccountKey": {
-          "minLength": 1,
-          "type": "string",
-          "environmentVariable": "BlobStorageAccountKey"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "AccountName",
-        "AccountKey"
-      ],
-      "type": "object"
-    },
     "DataProtectionSettings": {
       "properties": {
         "ContainerName": {
@@ -617,7 +597,6 @@
     "CertificatePrintingBatchesCreateStartDate",
     "KeyVaultUri",
     "RedisSettings",
-    "BlobStorageSettings",
     "DataProtectionSettings",
     "DfeSignInSettings",
     "ResultsAndCertificationInternalApiSettings",

--- a/yaml/stages/tlevels-shared-stage.yml
+++ b/yaml/stages/tlevels-shared-stage.yml
@@ -24,6 +24,7 @@ stages:
     - group: platform-global-${{parameters.applicationName}}
     - group: platform-${{parameters.environmentName}}
     - group: platform-${{parameters.environmentName}}-${{parameters.applicationName}}
+    - group: platform-${{parameters.environmentName}}-${{parameters.applicationName}}-kv
     - group: platform-global
     - name: SharedBaseName
       value: "s126${{parameters.sharedEnvironmentId}}-${{parameters.applicationName}}"

--- a/yaml/stages/tlevels-stage.yml
+++ b/yaml/stages/tlevels-stage.yml
@@ -28,6 +28,7 @@ stages:
       - group: platform-global-${{parameters.applicationName}}
       - group: platform-${{parameters.environmentName}}
       - group: platform-${{parameters.environmentName}}-${{parameters.applicationName}}
+      - group: platform-${{parameters.environmentName}}-${{parameters.applicationName}}-kv
       - name: BaseName
         value: "s126${{parameters.environmentId}}-${{parameters.applicationName}}-${{parameters.environmentName}}"
       - name: ResourceGroupName
@@ -63,9 +64,6 @@ stages:
           sharedEnvironmentId: ${{ parameters.sharedEnvironmentId }}
           environmentName: ${{ parameters.environmentName }}
           ConfigurationSecrets: 
-            BlobStorageAccountKey: $(BlobStorageAccountKey)
-            ConfigStorageAccountkey: $(ConfigStorageAccountkey)
-            ConfigurationStorageConnectionString: $(ConfigurationStorageConnectionString)
             DfeSignInApiSecret: $(DfeSignInApiSecret)
             DfeSignInClientSecret: $(DfeSignInClientSecret)
             GovUkNotifyApiKey: $(GovUkNotifyApiKey)
@@ -73,9 +71,7 @@ stages:
             OrdnanceSurveyPlacesApiPlacesKey: $(OrdnanceSurveyPlacesApiPlacesKey)
             PrintingApiPassword: $(PrintingApiPassword)
             RedisCacheConnection: $(RedisCacheConnection)
-            RedisCachePassword: $(RedisCachePassword)
             ResacSQLServiceAccountPassword: $(ResacSQLServiceAccountPassword)
-            SharedStorageAccountKey: $(SharedStorageAccountKey)
             SQLServerAdminPassword: $(SQLServerAdminPassword)
             sqlServerReplicaAdminPassword: $(sqlServerReplicaAdminPassword)
             UcasApiPassword: $(UcasApiPassword)


### PR DESCRIPTION
This PR updates YAML configuration that is required to migrate secrets from pipeline variable groups to Key Vaults. It ensures that secrets are now stored in Key Vaults instead of directly in variable groups. Additionally, unused variables that were discovered during testing have also been removed from config.