### PR TITLE
Fix Capitalisation for Parameter Metadata

### DIFF
--- a/yaml/jobs/tlevels-infrastructure-job.yml
+++ b/yaml/jobs/tlevels-infrastructure-job.yml
@@ -84,7 +84,7 @@ jobs:
             -coreRommExtractTrigger "$(coreRommExtractTrigger)"
             -specialismRommExtractTrigger "$(specialismRommExtractTrigger)"
             -providerAddressExtractTrigger "$(providerAddressExtractTrigger)"
-            -CertificateTrackingExtractTrigger "$(CertificateTrackingExtractTrigger)"
+            -certificateTrackingExtractTrigger "$(CertificateTrackingExtractTrigger)"
             -enableReplica $(enableReplica)
             -containerLifecyclePolicyRules $(containerLifecyclePolicyRules)
             -ipSecurityRestrictions $(ipSecurityRestrictions)


### PR DESCRIPTION
Fix capitalisation of ARM output parameter to ensure pipeline does not throw metadata related errors that have started occurring.