### PR TITLE
TL2023-1048: Amend Summer 2025 end date & add Autumn 2025 dates

### DIFF
--- a/src/Sfa.Tl.ResultsAndCertification.Database/PostDeployment/SeedAssessmentSeries.sql
+++ b/src/Sfa.Tl.ResultsAndCertification.Database/PostDeployment/SeedAssessmentSeries.sql
@@ -17,8 +17,10 @@ USING (VALUES
   (9, 2, N'Summer 2024', N'Summer 2024', 2024, N'2023-08-08', N'2024-08-05', N'2024-09-26', N'2024-10-31', NULL, NULL, NULL),
   (10, 1, N'Summer 2024', N'Summer 2024', 2024, N'2024-03-12', N'2024-08-05', N'2024-09-26', N'2024-10-31', 2022, N'2024-08-14', N'2024-11-01'),
   (11, 1, N'Autumn 2024', N'Autumn 2024', 2024, N'2024-08-06', N'2025-03-10', N'2025-05-01', N'2025-05-31', 2022, N'2025-03-19', N'2025-06-01'),
-  (12, 1, N'Summer 2025', N'Summer 2025', 2025, N'2025-03-11', N'2025-08-11', N'2025-09-26', N'2025-10-31', 2023, N'2025-08-20', N'2025-11-01'),
-  (13, 2, N'Summer 2025', N'Summer 2025', 2025, N'2024-08-06', N'2025-08-11', N'2025-09-26', N'2025-10-31', NULL, NULL, NULL)
+  (12, 1, N'Summer 2025', N'Summer 2025', 2025, N'2025-03-11', N'2025-08-05', N'2025-09-26', N'2025-10-31', 2023, N'2025-08-20', N'2025-11-01'),
+  (13, 2, N'Summer 2025', N'Summer 2025', 2025, N'2024-08-06', N'2025-08-05', N'2025-09-26', N'2025-10-31', NULL, NULL, NULL),
+  -- The following Autumn 2025 row is a placeholder and needs to be replaced with the correct dates in the future
+  (14, 1, N'Autumn 2025', N'Autumn 2025', 2025, N'2025-08-06', N'2026-03-10', N'2026-05-01', N'2026-05-31', 2023, N'2026-03-19', N'2026-06-01')
   )
   AS Source ([Id], [ComponentType], [Name], [Description], [Year], [StartDate], [EndDate], [RommEndDate], [AppealEndDate], [ResultCalculationYear], [ResultPublishDate], [PrintAvailableDate]) 
 ON Target.[Id] = Source.[Id] 


### PR DESCRIPTION
Through a support ticket we were investigating (TL2023-989), we realised that the end dates for Summer 2025 were wrong. Given that there's also no assessment series following it, the function would stop working once Summer 2025 finishes, so we've added a placeholder Autumn 2025 assessment series to keep it ticking until proper dates are obtained for future assessment series.

- Amend EndDate for Summer 2025 results
- Add placeholder Autumn 2025 dates