### PR TITLE
merge develop into master (Release24.4)

### DIFF
--- a/src/Sfa.Tl.ResultsAndCertification.Application/Services/ResultSlipsBuilder/ResultSlipBuilder.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Application/Services/ResultSlipsBuilder/ResultSlipBuilder.cs
@@ -147,9 +147,14 @@ namespace Sfa.Tl.ResultsAndCertification.Application.Services.ResultSlipsBuilder
                 int upperRightX = 250;
                 int upperRightY = 825;
 
-                using (FileStream imageStream = new FileStream(Common.Utils.Image.GetResultSlipHeaderLogo(), FileMode.Open))
+                string imagePath = Common.Utils.Image.GetResultSlipHeaderLogo();
+
+                using (MemoryStream memoryStream = new MemoryStream())
                 {
-                    _page.Resources.Images.Add(imageStream);
+                    CopyFileToStream(imagePath, memoryStream);
+
+                    memoryStream.Position = 0;
+                    _page.Resources.Images.Add(memoryStream);
 
                     _page.Contents.Add(new Aspose.Pdf.Operators.GSave());
 
@@ -161,8 +166,15 @@ namespace Sfa.Tl.ResultsAndCertification.Application.Services.ResultSlipsBuilder
 
                     _page.Contents.Add(new Aspose.Pdf.Operators.Do(ximage.Name));
                     _page.Contents.Add(new Aspose.Pdf.Operators.GRestore());
+
                 }
                 return this;
+            }
+
+            private static void CopyFileToStream(string imagePath, Stream targetStream)
+            {
+                using var fileStream = File.OpenRead(imagePath);
+                fileStream.CopyTo(targetStream);
             }
         }
     }

--- a/src/Sfa.Tl.ResultsAndCertification.Data/Repositories/DataExportRepository.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Data/Repositories/DataExportRepository.cs
@@ -205,6 +205,7 @@ namespace Sfa.Tl.ResultsAndCertification.Data.Repositories
                             .SelectMany(pr => pr.TqPathwayResults
                                 .Where(pr => pr.IsOptedin && pr.EndDate == null &&
                                     (pr.PrsStatus == PrsStatus.UnderReview || pr.PrsStatus == PrsStatus.Reviewed)))
+                                .OrderByDescending(pr => pr.TqPathwayAssessment.AssessmentSeriesId)
                                 .FirstOrDefault()
                                 .TqPathwayAssessment.AssessmentSeries.Name,
                     CoreComponentCode = romm.TqPathwayAssessments.First().TqRegistrationPathway.TqProvider.TqAwardingOrganisation.TlPathway.LarId,
@@ -218,6 +219,7 @@ namespace Sfa.Tl.ResultsAndCertification.Data.Repositories
                             .SelectMany(pr => pr.TqPathwayResults
                                 .Where(pr => pr.IsOptedin && pr.EndDate == null &&
                                     (pr.PrsStatus == PrsStatus.UnderReview || pr.PrsStatus == PrsStatus.Reviewed)))
+                                .OrderByDescending(pr => pr.TqPathwayAssessment.AssessmentSeriesId)
                                 .Select(pr => pr.PrsStatus == PrsStatus.UnderReview ? string.Empty : pr.TlLookup.Value)
                                 .FirstOrDefault(),
                     AssessmentSeriesSpecialisms = romm.TqRegistrationSpecialisms
@@ -227,6 +229,7 @@ namespace Sfa.Tl.ResultsAndCertification.Data.Repositories
                                     .SelectMany(sr => sr.TqSpecialismResults
                                         .Where(sr => sr.IsOptedin && sr.EndDate == null
                                             && (sr.PrsStatus == PrsStatus.UnderReview || sr.PrsStatus == PrsStatus.Reviewed)))
+                                        .OrderByDescending(pr => pr.TqSpecialismAssessment.AssessmentSeriesId)
                                         .FirstOrDefault()
                                         .TqSpecialismAssessment.AssessmentSeries.Name,
                     SpecialismComponentCode = romm.TqRegistrationSpecialisms.First().TlSpecialism.LarId,
@@ -244,6 +247,7 @@ namespace Sfa.Tl.ResultsAndCertification.Data.Repositories
                                 .SelectMany(sr => sr.TqSpecialismResults
                                     .Where(sr => sr.IsOptedin && sr.EndDate == null
                                         && (sr.PrsStatus == PrsStatus.UnderReview || sr.PrsStatus == PrsStatus.Reviewed)))
+                                    .OrderByDescending(pr => pr.TqSpecialismAssessment.AssessmentSeriesId)
                                     .Select(sr => sr.PrsStatus == PrsStatus.UnderReview ? string.Empty : sr.TlLookup.Value)
                                     .FirstOrDefault()
                 })

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Dashboard/ProviderDashboard.Designer.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Dashboard/ProviderDashboard.Designer.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Dashboard {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ProviderDashboard {
@@ -376,7 +376,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Dashboard {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Download a CSV file of your learners’ registration data, by start year..
+        ///   Looks up a localized string similar to Download a CSV file of your learners’ registration data, including industry placement status, by start year..
         /// </summary>
         public static string Tile_Para_Download_Csv_Learners_Registration_Data {
             get {

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Dashboard/ProviderDashboard.resx
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Dashboard/ProviderDashboard.resx
@@ -223,7 +223,7 @@
     <value>Upload industry placement data</value>
   </data>
   <data name="Tile_Para_Download_Csv_Learners_Registration_Data" xml:space="preserve">
-    <value>Download a CSV file of your learners’ registration data, by start year.</value>
+    <value>Download a CSV file of your learners’ registration data, including industry placement status, by start year.</value>
   </data>
   <data name="Tile_Para_Download_Results_For_Active_Learners" xml:space="preserve">
     <value>Download results for active learners in their final year of their T Level.</value>

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/ChangeAcademicYear.Designer.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/ChangeAcademicYear.Designer.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Registration {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class ChangeAcademicYear {
@@ -178,7 +178,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Registration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to What should the academic year to be?.
+        ///   Looks up a localized string similar to What should the academic year be?.
         /// </summary>
         public static string What_Should_The_Academic_Heading_Title {
             get {

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/ChangeAcademicYear.resx
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/ChangeAcademicYear.resx
@@ -139,7 +139,7 @@
     <value>ULN</value>
   </data>
   <data name="What_Should_The_Academic_Heading_Title" xml:space="preserve">
-    <value>What should the academic year to be?</value>
+    <value>What should the academic year be?</value>
   </data>
   <data name="Button_Cancel" xml:space="preserve">
     <value>Cancel</value>

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/Upload.Designer.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/Upload.Designer.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Registration {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Upload {
@@ -304,7 +304,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Registration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing, please wait. This could take up to 10 seconds. Do not refresh..
+        ///   Looks up a localized string similar to Processing, please wait. This could take up to two minutes. Do not refresh..
         /// </summary>
         public static string Upload_Processing_Spinner_Text {
             get {

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/Upload.resx
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/Upload.resx
@@ -199,6 +199,6 @@
     <value>Upload a file</value>
   </data>
   <data name="Upload_Processing_Spinner_Text" xml:space="preserve">
-    <value>Processing, please wait. This could take up to 10 seconds. Do not refresh.</value>
+    <value>Processing, please wait. This could take up to two minutes. Do not refresh.</value>
   </data>
 </root>

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Controllers/PostResultsServiceController.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Controllers/PostResultsServiceController.cs
@@ -247,6 +247,8 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Controllers
             if (checkAndSubmitDetails != null && (isChangeMode == null || isChangeMode.Value == false))
                 viewModel.SelectedGradeCode = viewModel.Grades?.FirstOrDefault(g => g.Value == checkAndSubmitDetails?.NewGrade)?.Code;
 
+            viewModel.Grades.Remove(viewModel.Grades.FirstOrDefault(g => g.Value == viewModel.Grade));
+
             viewModel.IsRommOutcomeJourney = isRommOutcomeJourney ?? false;
             viewModel.IsChangeMode = isChangeMode ?? false;
             return View(viewModel);
@@ -491,6 +493,8 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Controllers
             var checkAndSubmitDetails = await _cacheService.GetAsync<PrsAppealCheckAndSubmitViewModel>(CacheKey);
             if (checkAndSubmitDetails != null && (isChangeMode == null || isChangeMode.Value == false))
                 viewModel.SelectedGradeCode = viewModel.Grades?.FirstOrDefault(g => g.Value == checkAndSubmitDetails?.NewGrade)?.Code;
+
+            viewModel.Grades.Remove(viewModel.Grades.FirstOrDefault(g => g.Value == viewModel.Grade));
 
             viewModel.IsAppealOutcomeJourney = isAppealOutcomeJourney ?? false;
             viewModel.IsChangeMode = isChangeMode ?? false;

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Loader/ResultLoader.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Loader/ResultLoader.cs
@@ -127,7 +127,16 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Loader
                 return null;
 
             if (isChangeMode)
+            {
+                var currentGradeCode = assessment.Result?.GradeCode;
+
+                if (!string.IsNullOrWhiteSpace(currentGradeCode))
+                {
+                    grades.Remove(grades.Where(t => t.Code == currentGradeCode).FirstOrDefault());
+                }
+
                 grades.Insert(grades.Count, new LookupData { Code = Constants.NotReceived, Value = Content.Result.ManageCoreResult.Option_Remove_Result });
+            }
 
             return _mapper.Map<ManageCoreResultViewModel>(response, opt =>
             {
@@ -188,8 +197,16 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Loader
                 return null;
 
             if (isChangeMode)
+            {
+                var currentGradeCode = assessment.Result?.GradeCode;
+
+                if (!string.IsNullOrWhiteSpace(currentGradeCode))
+                {
+                    grades.Remove(grades.Where(t => t.Code == currentGradeCode).FirstOrDefault());
+                }
                 grades.Insert(grades.Count, new LookupData { Code = Constants.NotReceived, Value = Content.Result.ManageSpecialismResult.Option_Remove_Result });
 
+            }
             return _mapper.Map<ManageSpecialismResultViewModel>(response, opt =>
             {
                 opt.Items["grades"] = grades;

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Mapper/ResultMapper.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Mapper/ResultMapper.cs
@@ -72,6 +72,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Mapper
                 .ForMember(d => d.AssessmentId, opts => opts.MapFrom((src, dest, destMember, context) => ((Assessment)context.Items["assessment"])?.Id))
                 .ForMember(d => d.ResultId, opts => opts.MapFrom((src, dest, destMember, context) => ((Assessment)context.Items["assessment"]).Result?.Id))
                 .ForMember(d => d.CoreGradeCode, opts => opts.MapFrom((src, dest, destMember, context) => ((Assessment)context.Items["assessment"]).Result?.GradeCode))
+                .ForMember(d => d.SelectedGradeCode, opts => opts.MapFrom((src, dest, destMember, context) => ((Assessment)context.Items["assessment"]).Result?.GradeCode))
                 .ForMember(d => d.PathwayPrsStatus, opts => opts.MapFrom((src, dest, destMember, context) => ((Assessment)context.Items["assessment"]).Result?.PrsStatus))
                 .ForMember(d => d.Grades, opts => opts.MapFrom((src, dest, destMember, context) => (IList<LookupData>)context.Items["grades"]));
 

--- a/src/Tests/Sfa.Tl.ResultsAndCertification.Web.UnitTests/Loader/ResultLoaderTests/GetManageCoreResult/When_ChangeMode_HasResult.cs
+++ b/src/Tests/Sfa.Tl.ResultsAndCertification.Web.UnitTests/Loader/ResultLoaderTests/GetManageCoreResult/When_ChangeMode_HasResult.cs
@@ -19,7 +19,8 @@ namespace Sfa.Tl.ResultsAndCertification.Web.UnitTests.Loader.ResultLoaderTests.
             expectedApiLookupData = new List<LookupData>
             {
                 new LookupData { Id = 1, Code = "C1", Value = "V1" },
-                new LookupData { Id = 2, Code = "C2", Value = "V2" }
+                new LookupData { Id = 2, Code = "C2", Value = "V2" },
+                new LookupData { Id = 3, Code = "C3", Value = "V3" }
             };
 
             InternalApiClient.GetLookupDataAsync(LookupCategory.PathwayComponentGrade).Returns(expectedApiLookupData);
@@ -59,8 +60,9 @@ namespace Sfa.Tl.ResultsAndCertification.Web.UnitTests.Loader.ResultLoaderTests.
                             LastUpdatedOn = DateTime.UtcNow,
                             Result = new Result
                             {
-                                Id = 1,
+                                Id = 3,
                                 Grade = "A",
+                                GradeCode = "C3",
                                 PrsStatus = null,
                                 LastUpdatedBy = "System",
                                 LastUpdatedOn = DateTime.UtcNow

--- a/src/Tests/Sfa.Tl.ResultsAndCertification.Web.UnitTests/Loader/ResultLoaderTests/GetManageSpecialismResult/When_Called_With_IsChangeMode_True.cs
+++ b/src/Tests/Sfa.Tl.ResultsAndCertification.Web.UnitTests/Loader/ResultLoaderTests/GetManageSpecialismResult/When_Called_With_IsChangeMode_True.cs
@@ -20,8 +20,9 @@ namespace Sfa.Tl.ResultsAndCertification.Web.UnitTests.Loader.ResultLoaderTests.
             {
                 new LookupData { Id = 1, Code = "C1", Value = "V1" },
                 new LookupData { Id = 2, Code = "C2", Value = "V2" },
-                new LookupData { Code = "NR", Value = "This learner's grade has not been received" },
+                new LookupData { Code = "NR", Value = "This learner's grade has not been received" }
             };
+
 
             InternalApiClient.GetLookupDataAsync(LookupCategory.SpecialismComponentGrade).Returns(expectedApiLookupData);
 
@@ -130,6 +131,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.UnitTests.Loader.ResultLoaderTests.
                 ActualResult.Grades[i].Code.Should().Be(expectedApiLookupData[i].Code);
                 ActualResult.Grades[i].Value.Should().Be(expectedApiLookupData[i].Value);
             }
+
         }
 
         [Fact]


### PR DESCRIPTION
* Updated logic to return latest assessment for core and specialism to return the latest assessment in the export
* Content update
* Remove the current grade from the list when selecting romm/appeal grade change.
* Refactor image loading to use MemoryStream in PDF builder
* Allow AO to select only a grade different from previous one in result service
* Update upload spinner text