### PR TITLE
Increase upload limits and update processing messages

### DIFF
--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Assessment/Upload.Designer.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Assessment/Upload.Designer.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Assessment {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Upload {
@@ -286,7 +286,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Assessment {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing, please wait. This could take up to 10 seconds. Do not refresh..
+        ///   Looks up a localized string similar to Processing, please wait. This could take up to 2 minutes. Do not refresh..
         /// </summary>
         public static string Upload_Processing_Spinner_Text {
             get {

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Assessment/Upload.resx
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Assessment/Upload.resx
@@ -193,7 +193,7 @@
     <value>Upload a file</value>
   </data>
   <data name="Upload_Processing_Spinner_Text" xml:space="preserve">
-    <value>Processing, please wait. This could take up to 10 seconds. Do not refresh.</value>
+    <value>Processing, please wait. This could take up to 2 minutes. Do not refresh.</value>
   </data>
   <data name="Warning_Text" xml:space="preserve">
     <value>Warning</value>

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/IndustryPlacement/Upload.Designer.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/IndustryPlacement/Upload.Designer.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.IndustryPlacement {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Upload {
@@ -232,7 +232,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.IndustryPlacement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing, please wait. This could take up to 10 seconds. Do not refresh..
+        ///   Looks up a localized string similar to Processing, please wait. This could take up to 2 minutes. Do not refresh..
         /// </summary>
         public static string Upload_Processing_Spinner_Text {
             get {

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/IndustryPlacement/Upload.resx
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/IndustryPlacement/Upload.resx
@@ -175,7 +175,7 @@
     <value>Upload a file</value>
   </data>
   <data name="Upload_Processing_Spinner_Text" xml:space="preserve">
-    <value>Processing, please wait. This could take up to 10 seconds. Do not refresh.</value>
+    <value>Processing, please wait. This could take up to 2 minutes. Do not refresh.</value>
   </data>
   <data name="Warning_Text" xml:space="preserve">
     <value>Warning</value>

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/PostResultsService/UploadRomms.Designer.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/PostResultsService/UploadRomms.Designer.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.PostResultsService {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class UploadRomms {
@@ -304,7 +304,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.PostResultsService {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing, please wait. This could take up to 10 seconds. Do not refresh..
+        ///   Looks up a localized string similar to Processing, please wait. This could take up to 2 minutes. Do not refresh..
         /// </summary>
         public static string Upload_Processing_Spinner_Text {
             get {

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/PostResultsService/UploadRomms.resx
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/PostResultsService/UploadRomms.resx
@@ -181,7 +181,7 @@
     <value>Upload a file</value>
   </data>
   <data name="Upload_Processing_Spinner_Text" xml:space="preserve">
-    <value>Processing, please wait. This could take up to 10 seconds. Do not refresh.</value>
+    <value>Processing, please wait. This could take up to 2 minutes. Do not refresh.</value>
   </data>
   <data name="Romms_Template_Published_On" xml:space="preserve">
     <value>Published 25 September 2024</value>

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/UploadWithdrawals.Designer.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/UploadWithdrawals.Designer.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Registration {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class UploadWithdrawals {
@@ -286,7 +286,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Registration {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing, please wait. This could take up to 10 seconds. Do not refresh..
+        ///   Looks up a localized string similar to Processing, please wait. This could take up to 2 minutes. Do not refresh..
         /// </summary>
         public static string Upload_Processing_Spinner_Text {
             get {

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/UploadWithdrawals.resx
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Registration/UploadWithdrawals.resx
@@ -193,7 +193,7 @@
     <value>Upload a file</value>
   </data>
   <data name="Upload_Processing_Spinner_Text" xml:space="preserve">
-    <value>Processing, please wait. This could take up to 10 seconds. Do not refresh.</value>
+    <value>Processing, please wait. This could take up to 2 minutes. Do not refresh.</value>
   </data>
   <data name="Withdrawals_Template_Published_On" xml:space="preserve">
     <value>Published 30 June 2024</value>

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Result/Upload.Designer.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Result/Upload.Designer.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Result {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Upload {
@@ -286,7 +286,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.Content.Result {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Processing, please wait. This could take up to 10 seconds. Do not refresh..
+        ///   Looks up a localized string similar to Processing, please wait. This could take up to 2 minutes. Do not refresh..
         /// </summary>
         public static string Upload_Processing_Spinner_Text {
             get {

--- a/src/Sfa.Tl.ResultsAndCertification.Web/Content/Result/Upload.resx
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/Content/Result/Upload.resx
@@ -193,7 +193,7 @@
     <value>Upload a file</value>
   </data>
   <data name="Upload_Processing_Spinner_Text" xml:space="preserve">
-    <value>Processing, please wait. This could take up to 10 seconds. Do not refresh.</value>
+    <value>Processing, please wait. This could take up to 2 minutes. Do not refresh.</value>
   </data>
   <data name="Warning_Text" xml:space="preserve">
     <value>Warning</value>

--- a/src/Sfa.Tl.ResultsAndCertification.Web/ViewModel/Assessment/UploadAssessmentsRequestViewModel.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/ViewModel/Assessment/UploadAssessmentsRequestViewModel.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.ViewModel.Assessment
 
         [DataType(DataType.Upload)]
         [Required(ErrorMessageResourceType = typeof(ErrorResource.Upload), ErrorMessageResourceName = "Select_File_To_Upload_Required_Validation_Message")]
-        [FileValidation(AllowedExtensions = ".csv", MaxFileNameLength = 150, MaxFileSizeInMb = Constants.MaxFileSizeInMb, MaxRecordCount = 10000, ErrorResourceType = typeof(ErrorResource.Upload))]
+        [FileValidation(AllowedExtensions = ".csv", MaxFileNameLength = 150, MaxFileSizeInMb = Constants.MaxFileSizeInMb, MaxRecordCount = 20000, ErrorResourceType = typeof(ErrorResource.Upload))]
         public IFormFile File { get; set; }
                 
         public int? RequestErrorTypeId { get; set; }

--- a/src/Sfa.Tl.ResultsAndCertification.Web/ViewModel/IndustryPlacement/UploadIndustryPlacementsRequestViewModel.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/ViewModel/IndustryPlacement/UploadIndustryPlacementsRequestViewModel.cs
@@ -20,7 +20,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.ViewModel.IndustryPlacement
 
         [DataType(DataType.Upload)]
         [Required(ErrorMessageResourceType = typeof(ErrorResource.Upload), ErrorMessageResourceName = "Select_File_To_Upload_Required_Validation_Message")]
-        [FileValidation(AllowedExtensions = ".csv", MaxFileNameLength = 150, MaxFileSizeInMb = 2, MaxRecordCount = 1000, ValidateMinFileSize = true, ErrorResourceType = typeof(ErrorResource.Upload))]
+        [FileValidation(AllowedExtensions = ".csv", MaxFileNameLength = 150, MaxFileSizeInMb = 2, MaxRecordCount = 2000, ValidateMinFileSize = true, ErrorResourceType = typeof(ErrorResource.Upload))]
         public IFormFile File { get; set; }
 
         public int? RequestErrorTypeId { get; set; }

--- a/src/Sfa.Tl.ResultsAndCertification.Web/ViewModel/Registration/UploadRegistrationsRequestViewModel.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/ViewModel/Registration/UploadRegistrationsRequestViewModel.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.ViewModel.Registration
          
         [DataType(DataType.Upload)]
         [Required(ErrorMessageResourceType = typeof(ErrorResource.Upload), ErrorMessageResourceName = "Select_File_To_Upload_Required_Validation_Message")]
-        [FileValidation(AllowedExtensions = ".csv", MaxFileNameLength = 150, MaxFileSizeInMb = Constants.MaxFileSizeInMb, MaxRecordCount = 10000, ErrorResourceType = typeof(ErrorResource.Upload))]
+        [FileValidation(AllowedExtensions = ".csv", MaxFileNameLength = 150, MaxFileSizeInMb = Constants.MaxFileSizeInMb, MaxRecordCount = 20000, ErrorResourceType = typeof(ErrorResource.Upload))]
         public IFormFile File { get; set; }
 
         public int? RequestErrorTypeId { get; set; }        

--- a/src/Sfa.Tl.ResultsAndCertification.Web/ViewModel/Result/UploadResultsRequestViewModel.cs
+++ b/src/Sfa.Tl.ResultsAndCertification.Web/ViewModel/Result/UploadResultsRequestViewModel.cs
@@ -19,7 +19,7 @@ namespace Sfa.Tl.ResultsAndCertification.Web.ViewModel.Result
 
         [DataType(DataType.Upload)]
         [Required(ErrorMessageResourceType = typeof(ErrorResource.Upload), ErrorMessageResourceName = "Select_File_To_Upload_Required_Validation_Message")]
-        [FileValidation(AllowedExtensions = ".csv", MaxFileNameLength = 150, MaxFileSizeInMb = Constants.MaxFileSizeInMb, MaxRecordCount = 10000, ErrorResourceType = typeof(ErrorResource.Upload))]
+        [FileValidation(AllowedExtensions = ".csv", MaxFileNameLength = 150, MaxFileSizeInMb = Constants.MaxFileSizeInMb, MaxRecordCount = 20000, ErrorResourceType = typeof(ErrorResource.Upload))]
         public IFormFile File { get; set; }
 
         public int? RequestErrorTypeId { get; set; }


### PR DESCRIPTION
Increased max CSV record counts for bulk uploads (e.g., assessments, registrations, results, industry placements). Updated processing spinner text to indicate up to 2 minutes wait time.